### PR TITLE
use Debian format '3.0 (quilt)'

### DIFF
--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)


### PR DESCRIPTION
A native package shouldn't include a dash version.