### PR TITLE
fix several Lintian tags, create libubimockresolver0 package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -44,8 +44,7 @@ Description: Ubuntu artwork for Ubiquity live installer
 
 Package: ubiquity-frontend-gtk
 Architecture: any
-Pre-Depends: ${misc:Pre-Depends}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${python3:Depends}, ubiquity (= ${binary:Version}), python3-dbus, gir1.2-gtk-3.0, gir1.2-soup-2.4, gir1.2-vte-2.90, gir1.2-webkit-3.0, iso-codes, metacity | xfwm4 | matchbox-window-manager | lubuntu-default-settings | openbox | gnome-shell, gir1.2-xkl-1.0, gir1.2-timezonemap-1.0, python3-gi, python3-cairo, python3-gi-cairo, gir1.2-appindicator3-0.1, busybox-static | busybox
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${python3:Depends}, ubiquity (= ${binary:Version}), libubimockresolver0 (= ${binary:Version}), python3-dbus, gir1.2-gtk-3.0, gir1.2-soup-2.4, gir1.2-vte-2.90, gir1.2-webkit-3.0, iso-codes, metacity | xfwm4 | matchbox-window-manager | lubuntu-default-settings | openbox | gnome-shell, gir1.2-xkl-1.0, gir1.2-timezonemap-1.0, python3-gi, python3-cairo, python3-gi-cairo, gir1.2-appindicator3-0.1, busybox-static | busybox
 Suggests: gnome-control-center | feh
 Conflicts: ubuntu-express-frontend-gtk, espresso-frontend-gtk, ubiquity (<< 2.4.3)
 Replaces: ubuntu-express-frontend-gtk, espresso-frontend-gtk, ubiquity (<< 2.4.3)
@@ -53,6 +52,16 @@ Provides: ubiquity-frontend-${mangled-version}, indicator-renderer
 Description: GTK+ frontend for Ubiquity live installer
  This package provides a GTK+-based user interface frontend for the Ubiquity
  live CD installer.
+
+Package: libubimockresolver0
+Architecture: any
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Conflicts: ubuntu-express-frontend-gtk, espresso-frontend-gtk, ubiquity (<< 2.4.3)
+Replaces: ubuntu-express-frontend-gtk, espresso-frontend-gtk, ubiquity (<< 2.4.3)
+Description: shared library required by the GTK+ frontend for Ubiquity
+ This package provides a required shared library for the GTK+-based user
+ interface frontend for the Ubiquity live CD installer.
 
 Package: ubiquity-frontend-kde
 Architecture: all
@@ -84,7 +93,7 @@ Description: Perform end-user configuration after initial OEM installation
 
 Package: oem-config-gtk
 Architecture: all
-Depends: ${misc:Depends}, oem-config (= ${source:Version}), ubiquity-frontend-gtk (= ${source:Version}), python3-aptdaemon.gtk3widgets, aptdaemon
+Depends: ${misc:Depends}, ${python3:Depends}, python3 (>= 3.1), oem-config (= ${source:Version}), ubiquity-frontend-gtk (= ${source:Version}), python3-aptdaemon.gtk3widgets, aptdaemon
 Replaces: oem-config (<< 1.0)
 Provides: oem-config-frontend-${mangled-version}
 Description: GTK+ frontend for end-user post-OEM-install configuration
@@ -129,14 +138,14 @@ Package-Type: udeb
 Section: debian-installer
 Priority: standard
 Architecture: all
-Depends: cdebconf-udeb (>= 0.75), main-menu (>= 1.03)
+Depends: ${misc:Depends}, cdebconf-udeb (>= 0.75), main-menu (>= 1.03)
 Description: enter OEM mode if requested
 
 Package: oem-config-udeb
 Package-Type: udeb
 Section: debian-installer
 Architecture: all
-Depends: oem-config-check, cdebconf-udeb
+Depends: ${misc:Depends}, oem-config-check, cdebconf-udeb
 XB-Installer-Menu-Item: 2350
 Description: Prepare for OEM configuration
 

--- a/debian/libubimockresolver0.install
+++ b/debian/libubimockresolver0.install
@@ -1,0 +1,1 @@
+usr/lib/*/libubimockresolver.so.0*

--- a/debian/rules
+++ b/debian/rules
@@ -246,8 +246,8 @@ binary-indep: install-stamp
 	dh_compress
 	dh_fixperms
 	dh_python3 /usr/lib/ubiquity
-	dh_installdeb
 	dh_shlibdeps
+	dh_installdeb
 	dh_gencontrol -- -Vmangled-version='$(MANGLED_VERSION)'
 	dh_md5sums
 	NO_PNG_PKG_MANGLE=1 dh_builddeb -- -Zxz
@@ -288,8 +288,9 @@ binary-arch: install-stamp
 	dh_compress
 	dh_fixperms
 	dh_python3 /usr/lib/ubiquity
-	dh_installdeb
+	dh_makeshlibs
 	dh_shlibdeps
+	dh_installdeb
 	dh_gencontrol -- -V'console-setup-depends=$(console-setup-depends)' -Vmangled-version='$(MANGLED_VERSION)'
 	dh_md5sums
 	NO_PNG_PKG_MANGLE=1 dh_builddeb -- -Zxz

--- a/debian/ubiquity-frontend-gtk.install
+++ b/debian/ubiquity-frontend-gtk.install
@@ -10,8 +10,6 @@ pixmaps/zoom-in.png usr/share/ubiquity/pixmaps
 pixmaps/partitioner usr/share/ubiquity/pixmaps
 pixmaps/ubiquity.xpm usr/share/pixmaps
 
-usr/lib/*/*.a*
-usr/lib/*/*.so*
 usr/lib/*/girepository-1.0 usr/lib
 usr/lib/ubiquity
 usr/share/gir-1.0/*.gir

--- a/debian/ubiquity-frontend-gtk.lintian-overrides
+++ b/debian/ubiquity-frontend-gtk.lintian-overrides
@@ -1,2 +1,2 @@
-# ubiquity will installed as a dependency
+# ubiquity will be installed as a dependency
 ubiquity-frontend-gtk: menu-command-not-in-package usr/share/menu/ubiquity-frontend-gtk:5 usr/bin/ubiquity

--- a/debian/ubiquity-frontend-gtk.lintian-overrides
+++ b/debian/ubiquity-frontend-gtk.lintian-overrides
@@ -1,0 +1,2 @@
+# ubiquity will installed as a dependency
+ubiquity-frontend-gtk: menu-command-not-in-package usr/share/menu/ubiquity-frontend-gtk:5 usr/bin/ubiquity

--- a/debian/ubiquity-frontend-kde.lintian-overrides
+++ b/debian/ubiquity-frontend-kde.lintian-overrides
@@ -1,0 +1,2 @@
+# ubiquity will installed as a dependency
+ubiquity-frontend-kde: desktop-command-not-in-package usr/share/applications/kde4/ubiquity-kdeui.desktop ubiquity

--- a/debian/ubiquity-frontend-kde.lintian-overrides
+++ b/debian/ubiquity-frontend-kde.lintian-overrides
@@ -1,2 +1,2 @@
-# ubiquity will installed as a dependency
+# ubiquity will be installed as a dependency
 ubiquity-frontend-kde: desktop-command-not-in-package usr/share/applications/kde4/ubiquity-kdeui.desktop ubiquity


### PR DESCRIPTION
Fixes:
```
W: ubiquity-frontend-gtk: package-name-doesnt-match-sonames libubimockresolver0
W: ubiquity-frontend-gtk: non-dev-pkg-with-shlib-symlink usr/lib/x86_64-linux-gnu/libubimockresolver.so.0.0.0 usr/lib/x86_64-linux-gnu/libubimockresolver.so
E: ubiquity-frontend-gtk: no-shlibs-control-file usr/lib/x86_64-linux-gnu/libubimockresolver.so.0.0.0
E: ubiquity-frontend-gtk: postinst-must-call-ldconfig usr/lib/x86_64-linux-gnu/libubimockresolver.so.0.0.0
E: ubiquity-frontend-gtk: postrm-should-call-ldconfig usr/lib/x86_64-linux-gnu/libubimockresolver.so.0.0.0
E: oem-config-gtk: python-script-but-no-python-dep usr/sbin/oem-config-remove-gtk
```

Overridden:
```
W: ubiquity-frontend-gtk: menu-command-not-in-package usr/share/menu/ubiquity-frontend-gtk:5 usr/bin/ubiquity
W: ubiquity-frontend-kde: desktop-command-not-in-package usr/share/applications/kde4/ubiquity-kdeui.desktop ubiquity
```

There are still many Lintian tags left in the Ubiquity package:
```
E: ubiquity: no-debconf-config
W: ubiquity: malformed-prompt-in-templates debian-installer/dummy
W: ubiquity: malformed-question-in-templates debian-installer/framebuffer
W: ubiquity: using-first-person-in-templates ubiquity/text/login_pass
W: ubiquity: using-first-person-in-templates ubiquity/text/login_encrypt
W: ubiquity: using-first-person-in-templates ubiquity/text/crash_text_label
W: ubiquity: malformed-prompt-in-templates ubiquity/install/filesystem-images
W: ubiquity: malformed-question-in-templates ubiquity/install/generate-blacklist
W: ubiquity: malformed-question-in-templates ubiquity/partman-failed-unmount
W: ubiquity: using-question-in-extended-description-in-templates ubiquity/partman-failed-unmount
W: ubiquity: using-first-person-in-templates ubiquity/text/no_wireless
W: ubiquity: using-question-in-extended-description-in-templates ubiquity/partitioner/heading_one
W: ubiquity: using-question-in-extended-description-in-templates ubiquity/partitioner/heading_dual
W: ubiquity: using-question-in-extended-description-in-templates ubiquity/partitioner/heading_multiple
W: ubiquity: using-question-in-extended-description-in-templates ubiquity/partitioner/heading_no_detected
W: ubiquity: malformed-prompt-in-templates debian-installer/dummy
E: ubiquity: unknown-template-type terminal
W: ubiquity: using-question-in-extended-description-in-templates disk-detect/activate_mdadm
W: ubiquity: using-question-in-extended-description-in-templates disk-detect/activate_dmraid
W: ubiquity: using-question-in-extended-description-in-templates partman/unmount_active
E: ubiquity: unknown-template-type entropy
E: ubiquity: postrm-does-not-call-updaterc.d-for-init.d-script etc/init.d/ubiquity
W: ubiquity: init.d-script-not-marked-as-conffile etc/init.d/ubiquity
E: ubiquity: init.d-script-not-included-in-package etc/init.d/ubiquity
```