### PR TITLE
Fix bug when installing via PXE

### DIFF
--- a/d-i/source/apt-setup/apt-setup
+++ b/d-i/source/apt-setup/apt-setup
@@ -89,7 +89,11 @@ for generator in $gendir/*; do
 
 	progress_advance
 done
-mv $ROOT/etc/apt/sources.list.new $ROOT/etc/apt/sources.list
+if [ -e $ROOT/etc/apt/sources.list.new ]; then
+	mv $ROOT/etc/apt/sources.list.new $ROOT/etc/apt/sources.list
+else
+	touch $ROOT/etc/apt/sources.list
+fi
 if [ -s $ROOT/etc/apt/apt.conf.new ]; then
 	mv $ROOT/etc/apt/apt.conf.new $ROOT/etc/apt/apt.conf
 else

--- a/d-i/source/apt-setup/finish-install.d/10apt-cdrom-setup
+++ b/d-i/source/apt-setup/finish-install.d/10apt-cdrom-setup
@@ -14,8 +14,10 @@ fi
 
 # Comment out the cdrom entries and update APT's cache
 if [ "$disable_cdrom_entries" = "true" ]; then
-	logger -t finish-install "Disabling CDROM entries in sources.list"
-	sed -i "/^deb cdrom:/s/^/#/" /target/etc/apt/sources.list
+	if [ -e /target/etc/apt/sources.list ]; then
+		logger -t finish-install "Disabling CDROM entries in sources.list"
+		sed -i "/^deb cdrom:/s/^/#/" /target/etc/apt/sources.list
+	fi
 fi
 
 # Remove locale source


### PR DESCRIPTION
As already discussed on the mailing lists:
https://forums.linuxmint.com/viewtopic.php?t=233482
https://forums.linuxmint.com/viewtopic.php?t=176263#p911223

By default, ubiquity crashes when trying to install mint via PXE...