### PR TITLE
Fix GRUB menu not showing on multi-boot

### DIFF
--- a/d-i/source/grub-installer/grub-installer
+++ b/d-i/source/grub-installer/grub-installer
@@ -98,7 +98,7 @@ grub_serial_console() {
 	if [ -z "$speed" ]; then
 		speed="9600"
 	fi
-	case "$parity" in
+	case "$parity" in 
 		n) parity="--parity=no" ;;
 		e) parity="--parity=even" ;;
 		o) parity="--parity=odd" ;;
@@ -644,7 +644,7 @@ inst_package=$grub_package
 case "$grub_package" in
    *)
 	# Will pull in os-prober based on global setting for Recommends
-	apt-install $grub_package || exit_code=$?
+	apt-install $grub_package || exit_code=$? 
 	case $grub_package in
 	    *-signed)
 		apt-install shim-signed || true
@@ -716,11 +716,11 @@ if [ -s /tmp/os-probed ]; then
 		else
 			supported_os_list="$title"
 		fi
-
+		
 		IFS="$newline"
 	done
 	IFS="$OLDIFS"
-
+	
 	if [ -z "$OVERRIDE_UNSUPPORTED_OS" ] && [ -n "$unsupported_os_list" ]; then
 		# Unsupported OS, jump straight to manual boot device question.
 		state=2
@@ -1294,7 +1294,7 @@ if [ "$grub_version" = "grub" ] ; then
 					db_progress STOP
 					exit 10
 				fi
-
+				
 				db_get grub-installer/password-again
 				if [ "$password" = "$RET" ]; then
 					break
@@ -1333,7 +1333,7 @@ if [ "$grub_version" = "grub" ] ; then
 		# contains a password.
 		chmod o-r $ROOT/boot/grub/$menu_file
 		rm -f /tmp/menu.lst.password
-	fi
+	fi 
 fi
 
 # Add user parameters to menu.lst; some options are only added to the
@@ -1445,7 +1445,7 @@ if [ "$serial" ] ; then
 		update_grub # propagate to grub.cfg
 		;;
 	esac
-fi
+fi 
 
 # Generate menu.lst additions for other OSes
 tmpfile=/tmp/menu.lst.extras

--- a/d-i/source/grub-installer/grub-installer
+++ b/d-i/source/grub-installer/grub-installer
@@ -1401,7 +1401,7 @@ if [ -s /tmp/os-probed ]; then
 	else
 		sed -i 's/^GRUB_HIDDEN_TIMEOUT=.*/#&/;
 			s/^GRUB_TIMEOUT_STYLE=.*/GRUB_TIMEOUT_STYLE=menu/;
-			s/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=10/;' \
+			s/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=10/' \
 			$ROOT/etc/default/grub
 		update_grub # propagate to grub.cfg
 	fi

--- a/d-i/source/grub-installer/grub-installer
+++ b/d-i/source/grub-installer/grub-installer
@@ -98,7 +98,7 @@ grub_serial_console() {
 	if [ -z "$speed" ]; then
 		speed="9600"
 	fi
-	case "$parity" in 
+	case "$parity" in
 		n) parity="--parity=no" ;;
 		e) parity="--parity=even" ;;
 		o) parity="--parity=odd" ;;
@@ -644,7 +644,7 @@ inst_package=$grub_package
 case "$grub_package" in
    *)
 	# Will pull in os-prober based on global setting for Recommends
-	apt-install $grub_package || exit_code=$? 
+	apt-install $grub_package || exit_code=$?
 	case $grub_package in
 	    *-signed)
 		apt-install shim-signed || true
@@ -716,11 +716,11 @@ if [ -s /tmp/os-probed ]; then
 		else
 			supported_os_list="$title"
 		fi
-		
+
 		IFS="$newline"
 	done
 	IFS="$OLDIFS"
-	
+
 	if [ -z "$OVERRIDE_UNSUPPORTED_OS" ] && [ -n "$unsupported_os_list" ]; then
 		# Unsupported OS, jump straight to manual boot device question.
 		state=2
@@ -1294,7 +1294,7 @@ if [ "$grub_version" = "grub" ] ; then
 					db_progress STOP
 					exit 10
 				fi
-				
+
 				db_get grub-installer/password-again
 				if [ "$password" = "$RET" ]; then
 					break
@@ -1333,7 +1333,7 @@ if [ "$grub_version" = "grub" ] ; then
 		# contains a password.
 		chmod o-r $ROOT/boot/grub/$menu_file
 		rm -f /tmp/menu.lst.password
-	fi 
+	fi
 fi
 
 # Add user parameters to menu.lst; some options are only added to the
@@ -1400,7 +1400,8 @@ if [ -s /tmp/os-probed ]; then
 			$ROOT/boot/grub/menu.lst
 	else
 		sed -i 's/^GRUB_HIDDEN_TIMEOUT=.*/#&/;
-			s/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=10/' \
+			s/^GRUB_TIMEOUT_STYLE=.*/GRUB_TIMEOUT_STYLE=menu/;
+			s/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=10/;' \
 			$ROOT/etc/default/grub
 		update_grub # propagate to grub.cfg
 	fi
@@ -1412,6 +1413,7 @@ elif [ -n "$timeout" ]; then
 			$ROOT/boot/grub/menu.lst
 	else
 		sed -i 's/^GRUB_HIDDEN_TIMEOUT=.*/#&/;
+			s/^GRUB_TIMEOUT_STYLE=.*/GRUB_TIMEOUT_STYLE=menu/;
 			s/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT='$timeout'/' \
 			$ROOT/etc/default/grub
 		update_grub # propagate to grub.cfg
@@ -1443,7 +1445,7 @@ if [ "$serial" ] ; then
 		update_grub # propagate to grub.cfg
 		;;
 	esac
-fi 
+fi
 
 # Generate menu.lst additions for other OSes
 tmpfile=/tmp/menu.lst.extras


### PR DESCRIPTION
Adds support for the new default GRUB_TIMEOUT_STYLE in addition to the deprecated GRUB_HIDDEN_TIMEOUT.