### PR TITLE
Revert "Fix GRUB menu not showing on multi-boot (#41)"

### DIFF
--- a/d-i/source/grub-installer/grub-installer
+++ b/d-i/source/grub-installer/grub-installer
@@ -1400,7 +1400,6 @@ if [ -s /tmp/os-probed ]; then
 			$ROOT/boot/grub/menu.lst
 	else
 		sed -i 's/^GRUB_HIDDEN_TIMEOUT=.*/#&/;
-			s/^GRUB_TIMEOUT_STYLE=.*/GRUB_TIMEOUT_STYLE=menu/;
 			s/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=10/' \
 			$ROOT/etc/default/grub
 		update_grub # propagate to grub.cfg
@@ -1413,7 +1412,6 @@ elif [ -n "$timeout" ]; then
 			$ROOT/boot/grub/menu.lst
 	else
 		sed -i 's/^GRUB_HIDDEN_TIMEOUT=.*/#&/;
-			s/^GRUB_TIMEOUT_STYLE=.*/GRUB_TIMEOUT_STYLE=menu/;
 			s/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT='$timeout'/' \
 			$ROOT/etc/default/grub
 		update_grub # propagate to grub.cfg


### PR DESCRIPTION
This reverts commit a549e872e8dd06c10a7afa5423ef710e14e2d161.

Turns out /etc/grub.d/30_os-prober overrides this, anyway, so that entire /etc/default/grub modification section in ubiquity is actually irrelevant (and has been since 2014). Reverting just the commit to simplify future rebasing.