### PR TITLE
Add Occitan to language selection

### DIFF
--- a/d-i/source/localechooser/languagelist
+++ b/d-i/source/localechooser/languagelist
@@ -74,6 +74,7 @@ se_NO;Northern Sami;Sámegillii;1;NO;se_NO;se_NO:nb_NO:nb:no_NO:no:nn_NO:nn:da:s
 nb_NO;Norwegian Bokmaal;Norsk bokmål;1;NO;nb_NO.UTF-8;nb_NO:nb:no_NO:no:nn_NO:nn:en;console-setup
 nn_NO;Norwegian Nynorsk;Norsk nynorsk;1;NO;nn_NO.UTF-8;nn_NO:nn:no_NO:no:nb_NO:nb:en;console-setup
 #X os;Ossetian;Ирон æвзаг;3;RU;os_RU;;console-setup
+oc;Occitan;Occitan;1;FR;oc_FR.UTF-8;;console-setup
 fa;Persian;فارسی;3;IR;fa_IR;;console-setup
 pl;Polish;Polski;2;PL;pl_PL.UTF-8;;console-setup
 pt;Portuguese;Português;1;PT;pt_PT.UTF-8;pt:pt_BR:en;console-setup


### PR DESCRIPTION
Occitan is spelt «Occitan» in Occitan too.