### PR TITLE
Ubiquity: make installer window resizable (like Ubuntu does)

### DIFF
--- a/ubiquity/frontend/gtk_ui.py
+++ b/ubiquity/frontend/gtk_ui.py
@@ -1055,7 +1055,7 @@ class Wizard(BaseFrontend):
         # Window should be resizable for better overview while partitioning
         # instead of fixing the window size. The general defaulted size
         # is okay, and the window can be dragged by ALT-click as explained 
-        # in the relaese notes. Trie undefined so we use 1.
+        # in the relaese notes. TRUE is undefined so we use 1.
         self.live_installer.set_resizable(1)
 
         def expand(widget):

--- a/ubiquity/frontend/gtk_ui.py
+++ b/ubiquity/frontend/gtk_ui.py
@@ -1051,9 +1051,12 @@ class Wizard(BaseFrontend):
         self.vte.set_font(fontdesc)
         self.vte.show()
         misc.regain_privileges_save()
-        # FIXME shrink the window horizontally instead of locking the window
-        # size.
-        self.live_installer.set_resizable(False)
+        
+        # Window should be resizable for better overview while partitioning
+        # instead of fixing the window size. The general defaulted size
+        # is okay, and the window can be dragged by ALT-click as explained 
+        # in the relaese notes. Trie undefined so we use 1.
+        self.live_installer.set_resizable(1)
 
         def expand(widget):
             if widget.get_property('expanded'):


### PR DESCRIPTION
After six years and about 30, 50 installs where I changed the python line manually at install start a new try to get this single bit changed in the installer...