### PR TITLE
Fix Dutch language translation typo

### DIFF
--- a/debian/real-po/nl.po
+++ b/debian/real-po/nl.po
@@ -372,7 +372,7 @@ msgstr "Automatisch aanmelden"
 #. Description
 #: ../ubiquity.templates:51001
 msgid "Require my password to log in"
-msgstr "Mijn wachtwoord vergen om aan te melden"
+msgstr "Mijn wachtwoord vragen om aan te melden"
 
 #. Type: text
 #. Description


### PR DESCRIPTION
Fixes https://github.com/linuxmint/ubiquity/issues/56

## Done

Fix typo `vergen` -> `vragen`