### PR TITLE
grub-installer: Show the grub menu for 3 seconds for single-os installs

### DIFF
--- a/d-i/source/grub-installer/grub-installer
+++ b/d-i/source/grub-installer/grub-installer
@@ -1426,7 +1426,8 @@ elif [ -n "$timeout" ]; then
 			$ROOT/boot/grub/menu.lst
 	else
 		sed -i 's/^GRUB_HIDDEN_TIMEOUT=.*/#&/;
-			s/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT='$timeout'/' \
+			s/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=3/;
+			s/^GRUB_TIMEOUT_STYLE=.*/GRUB_TIMEOUT_STYLE=menu/' \
 			$ROOT/etc/default/grub
 		update_grub # propagate to grub.cfg
 	fi


### PR DESCRIPTION
GRUB_TIMEOUT_STYLE=menu needs to be added because the default is 'hidden' (this isn't needed when there are multiple OS entries, it seems to use 'menu' then without being told).