### PR TITLE
Fix: setupcon FONT variable fails to load font

### DIFF
--- a/d-i/source/console-setup/setupcon
+++ b/d-i/source/console-setup/setupcon
@@ -678,7 +678,6 @@ CONSOLE_MAP=${CONSOLE_MAP:-$ACM}
 FONTFILES=''
 if [ "$FONT" ]; then
     for f in $FONT; do
-        FONTFILES="$FONTFILES `findfile $fontdir $f`"
         RES=`findfile $fontdir $f`
         if [ -z "$RES" ]; then
             fdec="${f%.gz}"


### PR DESCRIPTION
Explanation to solution:

When running setupcon --print-commands-only we are met with the following setfont usage:
setfont '-C' '/dev/tty1' '/usr/share/consolefonts/ter-powerline-v14b.psf.gz' '/usr/share/consolefonts/ter-powerline-v14b.psf.gz'

The problem is that the setfont command should not be called with the font file several times.

The bug can be traced to d-i/source/console-setup/setupcon.sh in line 681.
Since the path of the file is found in findfile so FONTFILES and RES contain the name of the file.
Then at the end of the loop when concatenating RES to FONTFILES we basically add the font twice, which results in it showing twice in setfont.